### PR TITLE
Add AvailabilityTest function

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -90,7 +90,16 @@ Dependencies := rec(
 ),
 
 AvailabilityTest := function()
-        return true;
+      local so_file;
+      so_file := Filename(DirectoriesPackagePrograms("NautyTracesInterface"),
+                              "NautyTracesInterface.so");
+      if (not "NautyTracesInterface" in SHOW_STAT()) and so_file = fail then
+         LogPackageLoadingMessage(PACKAGE_WARNING,
+                                  ["the kernel module is not compiled, ", 
+                                   "the package cannot be loaded."] );
+         return fail;
+      fi;
+      return true;
     end,
 
 TestFile := "tst/testall.g",


### PR DESCRIPTION
Currently it is possible to load `NautyTracesInterface` when it is not compiled, and hence doesn't actually work. This PR modifies the `AvailabilityTest` function in `PackageInfo.g` so that the package won't load if it is not compiled.