### PR TITLE
Speed up repeated isomorphism checks.

### DIFF
--- a/gap/NautyGraph.gd
+++ b/gap/NautyGraph.gd
@@ -17,6 +17,7 @@ DeclareProperty( "IsColored", IsNautyGraph );
 DeclareAttribute( "AutomorphismGroup", IsNautyGraph );
 DeclareAttribute( "AutomorphismGroupGenerators", IsNautyGraph );
 DeclareAttribute( "CanonicalLabeling", IsNautyGraph );
+DeclareAttribute( "CanonicalLabelingInverse", IsNautyGraph );
 DeclareAttribute( "CanonicalForm", IsNautyGraph );
 
 DeclareOperation( "IsomorphismGraphs", [ IsNautyGraph, IsNautyGraph ] );


### PR DESCRIPTION
Store the modified graphs in CanonicalForm. This speeds up repeated
comparisons considerably (in my example it reduces time to 1/10th).
Store the inverted canonical labels (to avoid recomputing them often).