### PR TITLE
Speed up constructors in NautyTracesInterface.gi

### DIFF
--- a/gap/NautyTracesInterface.gi
+++ b/gap/NautyTracesInterface.gi
@@ -11,10 +11,16 @@
 InstallGlobalFunction( NautyGraphFromEdges,
   
   function( edges )
-    local source_list, range_list;
-    
-    source_list := List( edges, i -> i[ 1 ] );
-    range_list := List( edges, i -> i[ 2 ] );
+    local source_list, range_list, i;
+
+    source_list := [];
+    range_list := [];
+    for i in [ 1 .. Length( edges ) ] do
+        if IsBound( edges[ i ] ) then
+            source_list[ i ] := edges[ i ][ 1 ];
+            range_list[ i ] := edges[ i ][ 2 ];
+        fi;
+    od;
     
     return [ source_list, range_list ];
     
@@ -25,7 +31,7 @@ InstallGlobalFunction( NautyColorData,
   function( list )
     local color_list, node_list, list_pos, current_color, current_entry, colors;
     
-    colors := SortedList( DuplicateFreeList( list ) );
+    colors := Set( list );
     
     color_list := [];
     node_list := [];


### PR DESCRIPTION
This concerns two changes:
1) The two list commands in NautyGraphFromEdges are combined into one
loop. Therefore the list "edges" is only traversed once. Furthermore the
function call i->i[1] is replaced in both cases, which gives another
factor of 2.
2) The combination SortedList(DuplicateFreeList()) is replaced by Set(),
which gives a huge speedup, as shown in this example:
```
gap> L := List( [1..10^4], Phi );;
gap> Set(L);; time;
6
gap> SortedList(DuplicateFreeList(L));; time;
15
gap> L := List( [1..10^6], Phi );;
gap> Set(L);; time;
192
gap> SortedList(DuplicateFreeList(L));; time;
53843
```